### PR TITLE
Fix CORS error affecting front-end. Fix for the issue when Seeding the Player

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,8 +16,8 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
-        \App\Http\Middleware\TrustProxies::class,
         \Fruitcake\Cors\HandleCors::class,
+        \App\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
         \App\Http\Middleware\TrimStrings::class,

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "guzzlehttp/guzzle": "^6.3.1|^7.4",
         "laravel/fortify": "^1.0",
         "laravel/framework": "^8.0",
+        "laravel/legacy-factories": "^1.3",
         "laravel/passport": "^10.0",
         "laravel/tinker": "^2.7",
         "laravel/ui": "^3.0",


### PR DESCRIPTION
### Context: 
Running the s4yt api locally has been a pain due to issues surrounding CORS and seeding the database.
This PR addresses both issues.

**CORS issue:** This was happening due to the requests being rejected by other middlewares with higher priority.
The CORS middleware Fruitcake was placed lower in the code thus requests got refused by middleware on top

**Seeding Player Issue:** In laravel 8 the default route namespace was removed i.e the helper method `factory()` was removed in Laravel 8 thus it refused to help Seed the Player table.