### PR TITLE
Add validation to user on register

### DIFF
--- a/src/v2/models/user.ts
+++ b/src/v2/models/user.ts
@@ -25,7 +25,6 @@ const userSchema = new Schema<User>({
   region: {
     type: String,
     default: null,
-    minlength: [2, 'Region name is too short. Minimum length is 2 characters.'],
     maxlength: [50, 'Region name is too long. Maximum length is 50 characters.']
   },
   city: { type: String, default: null },

--- a/src/v2/models/user.ts
+++ b/src/v2/models/user.ts
@@ -9,7 +9,12 @@ const userSchema = new Schema<User>({
     required: true,
     unique: true
   },
-  name: { type: String, default: null, minlength: 2, maxlength: 128 },
+  name: {
+    type: String,
+    default: null,
+    minlength: [2, 'Name is too short. Minimum length is 2 characters.'],
+    maxlength: [128, 'Name is too long. Maximum length is 128 characters.']
+  },
   education: {
     type: String,
     enum: userEducation
@@ -17,7 +22,12 @@ const userSchema = new Schema<User>({
   school: { type: String, default: null },
   password: { type: String, required: true },
   country: { type: String, default: null },
-  region: { type: String, default: null },
+  region: {
+    type: String,
+    default: null,
+    minlength: [2, 'Region name is too short. Minimum length is 2 characters.'],
+    maxlength: [50, 'Region name is too long. Maximum length is 50 characters.']
+  },
   city: { type: String, default: null },
   chests_submitted: { type: Map, of: Number },
   is_email_verified: { type: Boolean, default: false },

--- a/src/v2/models/user.ts
+++ b/src/v2/models/user.ts
@@ -22,12 +22,12 @@ const userSchema = new Schema<User>({
   school: { type: String, default: null },
   password: { type: String, required: true },
   country: { type: String, default: null },
-  region: {
+  region: { type: String, default: null },
+  city: {
     type: String,
     default: null,
-    maxlength: [50, 'Region name is too long. Maximum length is 50 characters.']
+    maxlength: [50, 'City name is too long. Maximum length is 50 characters.']
   },
-  city: { type: String, default: null },
   chests_submitted: { type: Map, of: Number },
   is_email_verified: { type: Boolean, default: false },
   email_verification_token: { type: String, default: null },


### PR DESCRIPTION
Register service now checks if the user's name and city name are of valid lengths before continuing with the rest of the registration process. If the name and/or city is invalid, the registration coin award, referral bonus, verification email, and saving to DB steps are skipped and an error message is returned in the response.